### PR TITLE
Replace several pre-commit hooks by ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 160
-extend-ignore = E203, E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-added-large-files
-      - id: check-ast
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-json
@@ -38,7 +37,6 @@ repos:
       # - id: detect-aws-credentials
       - id: check-xml
       - id: check-yaml
-      - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -48,7 +46,6 @@ repos:
       - id: no-commit-to-branch
       # - id: pretty-format-json
       - id: requirements-txt-fixer
-      - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
@@ -79,23 +76,10 @@ repos:
     hooks:
       - id: shellcheck
 
-  - repo: https://github.com/pycqa/pydocstyle.git
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        additional_dependencies: ["tomli"]
-
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
     rev: v1.7.1.15
     hooks:
       - id: actionlint
-
-  - repo: https://github.com/pycqa/flake8
-    rev: "7.1.0"
-    hooks:
-      - id: flake8
-        additional_dependencies:
-        - pep8-naming
 
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.35.1
@@ -107,10 +91,8 @@ repos:
     rev: v0.4.10
     hooks:
       - id: ruff
-        files: ^(scripts|tests|custom_components)/.+\.py$
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix, --config=ruff.toml]
       - id: ruff-format
-        files: ^(scripts|tests|custom_components)/.+\.py$
 
   - repo: local
     hooks:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,28 @@
+[lint]
+extend-fixable = [
+    #Instead of trailing-whitespace
+    "W291", "W293"
+    ]
+
+extend-select = [
+    # Instead of pydocstyle
+    "D",
+    #Instead of flake8
+    "E", "F","B",
+    # Instead of pep8-naming
+    "N",
+    # Instead of flake8-debugger or debug-statements
+    "T10",
+]
+
+ignore = [
+    "E203",
+    "E501",
+
+    # Avoid incompatible rules
+    "D203",
+    "D213",
+]
+
+[lint.pycodestyle]
+max-line-length = 160


### PR DESCRIPTION
I have been looking into the pre commit hooks and when I got to the pydocstyle I tried to learn more about it.
So I went to the [pydocstyle repo](https://github.com/PyCQA/pydocstyle) and is officially deprecated in favor of ruff.

We are trying this ruff configuration that can replace pydocstyle and other hooks, like flake8.